### PR TITLE
Change spectral calibration task to jump crystal insertion task

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ You can also run the app using [VSCode dev containers](https://code.visualstudio
 * Make a jump [Admin UI Jump drive tab tab](http://localhost:8090/#/jump)
     - `Move to calculating` --> OK
     - `Approve jump` --> OK
-    - `Mark spectral calibration done` --> OK
+    - (**Expired!** `Mark spectral calibration done` --> OK)
+    - `Mark jump crystal change done`
     - `Mark jump reactor done` --> OK
     - `Next state (prep complete)` --> OK
     - `Initiate jump` --> OK --> Wait 60 seconds

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ You can also run the app using [VSCode dev containers](https://code.visualstudio
 * Make a jump [Admin UI Jump drive tab tab](http://localhost:8090/#/jump)
     - `Move to calculating` --> OK
     - `Approve jump` --> OK
-    - (**Expired!** `Mark spectral calibration done` --> OK)
-    - `Mark jump crystal change done`
+    - `Mark jump crystal change done` --> OK
     - `Mark jump reactor done` --> OK
     - `Next state (prep complete)` --> OK
     - `Initiate jump` --> OK --> Wait 60 seconds

--- a/src/views/JumpDrive.vue
+++ b/src/views/JumpDrive.vue
@@ -65,8 +65,8 @@
         <tr v-if="jump.status === 'preparation'">
           <th>Prep tasks:</th>
           <td class="value">
-            <span :class="spectralCalibrationStatus"
-              >Spectral calibration: {{ spectralCalibrationStatus }}</span
+            <span :class="jumpCrystalStatus"
+              >Jump crystal inserted: {{ jumpCrystalStatus }}</span
             ><br />
             <span :class="jumpReactorStatus"
               >Jump reactor: {{ jumpReactorStatus }}</span
@@ -112,28 +112,28 @@
       </div>
       <div v-if="jump.status === 'preparation'">
         <b-button
-          v-if="spectralCalibrationStatus === 'broken'"
-          variant="primary"
-          @click="
-            writeBlob({
-              type: 'box',
-              id: 'jump_drive_spectral_calibration',
-              status: 'fixed',
-            })
-          "
-          >Mark spectral calibration done</b-button
-        >
-        <b-button
-          v-if="spectralCalibrationStatus !== 'broken'"
+          v-if="jumpCrystalStatus === 'broken'"
           variant="danger"
           @click="
             writeBlob({
-              type: 'box',
-              id: 'jump_drive_spectral_calibration',
+              type: 'game',
+              id: 'jump_drive_insert_jump_crystal',
+              status: 'fixed',
+            })
+          "
+          >Mark jump crystal insertion done</b-button
+        >
+        <b-button
+          v-if="jumpCrystalStatus !== 'broken'"
+          variant="danger"
+          @click="
+            writeBlob({
+              type: 'game',
+              id: 'jump_drive_insert_jump_crystal',
               status: 'broken',
             })
           "
-          >Mark spectral calibration NOT done</b-button
+          >Mark jump crystal insertion NOT done</b-button
         >
         <b-button
           v-if="jumpReactorStatus === 'broken'"
@@ -351,10 +351,10 @@ export default {
     jumpSecs() {
       return (Date.now() - this.jump.last_jump) / 1000;
     },
-    spectralCalibrationStatus() {
+    jumpCrystalStatus() {
       return this.$store.state.dataBlobs.find(
         (blob) =>
-          blob.type === "task" && blob.id === "jump_drive_spectral_calibration",
+          blob.type === "task" && blob.id === "jump_drive_insert_jump_crystal",
       ).status;
     },
     jumpReactorStatus() {

--- a/src/views/JumpDrive.vue
+++ b/src/views/JumpDrive.vue
@@ -69,7 +69,7 @@
           </td>
           <td>
             <b-button variant="outline-primary" @click="fetchJumpCrystalCount()"
-              >Refresh ship data (data age: {{ fetchAgo }}s)</b-button
+              >Refresh crystal count (data age: {{ fetchAgo }}s)</b-button
             >
           </td>
         </tr>


### PR DESCRIPTION
Old Spectral Calibration task cannot be reused so the task is now changed to a manual engineering task to insert jump crystal to the jump drive. The task can be performed using HANSCA by the players. No need GMs to mark it done.

![image](https://github.com/OdysseusLarp/odysseus-admin/assets/36162517/271c9053-7748-4834-aabb-7a53789f0981)