### PR TITLE
Empty Epsilon admin view improvements

### DIFF
--- a/src/components/EmptyEpsilon.vue
+++ b/src/components/EmptyEpsilon.vue
@@ -199,27 +199,29 @@
                 >
                 </b-input>
               </b-form-group>
+              <div class="form-button-container">
+                <b-button variant="primary" @click="setValue()" size="md">Set value</b-button>
               </div>
-              <b-button variant="primary" @click="setValue()" size="sm"
-                >Set value</b-button
-              >
+              </div>
             </b-form>
             <hr />
           </div>
           <div class="ee-status-container">
             <h3>Break a task</h3>
             <b-form>
-              <b-form-group label="Task to break" label-for="selected-type">
-                <b-form-select
-                  id="selected-type"
-                  v-model="selectedTaskToBreak"
-                  :options="tasksNotBroken"
-                ></b-form-select>
-              </b-form-group>
+              <div class="ee-patch-values-form">
+                <b-form-group label="Task to break" label-for="selected-type">
+                  <b-form-select
+                    id="selected-type"
+                    v-model="selectedTaskToBreak"
+                    :options="tasksNotBroken"
+                  ></b-form-select>
+                </b-form-group>
+                <div class="form-button-container">
+                  <b-button variant="primary" @click="breakTask()" size="md">Break task</b-button>
+                </div>
+              </div>
               <p>{{ taskDealtDamage }}</p>
-              <b-button variant="primary" @click="breakTask()" size="sm"
-                >Break task</b-button
-              >
             </b-form>
           </div>
         </b-col>
@@ -602,6 +604,11 @@ button {
 }
 .vjs-tree .vjs-value__number {
   color: #1a3199;
+}
+.form-button-container {
+  flex: 0 !important;
+  align-content: flex-end;
+  padding-bottom: 1rem;
 }
 .ee-patch-values-form {
   display: flex;

--- a/src/components/EmptyEpsilon.vue
+++ b/src/components/EmptyEpsilon.vue
@@ -142,6 +142,17 @@
             <hr />
           </div>
           <div class="ee-status-container">
+            <h3>Landing pad statuses</h3>
+            <!-- For each key/value in gameState.landingPads print out stuff-->
+             <div class="landing-pad-container">
+              <div v-for="([key, value]) in landingPadStatus" :key="key" class="landing-pad-status" :class="getLandingPadClass(value)">
+              <strong>{{ getLandingPadName(key) }}</strong>
+              <span>{{ getLandingPadState(value) }}</span>
+            </div>
+             </div>
+            <hr />
+          </div>
+          <div class="ee-status-container">
             <h3>Update values</h3>
             <b-form>
               <div class="ee-patch-values-form">
@@ -285,6 +296,13 @@ export default {
         (e) => e.type === "ship" && e.id === "ee_metadata",
       );
     },
+    landingPadStatus() {
+    const landingPads = Object.entries(
+      _.get(this.gameState, "landingPads", {})
+    );
+    // Sort by key
+    return landingPads.sort(([a], [b]) => a.localeCompare(b));
+  },
     shipMetadata() {
       return this.$store.state.dataBlobs.find(
         (e) => e.type === "ship" && e.id === "metadata",
@@ -354,7 +372,57 @@ export default {
           this.errors.push("" + error);
           this.isLoading = false;
         });
-
+    },
+    getLandingPadName(key) {
+      switch (key) {
+        case "landingPadStatus1": {
+          return "Fighter 1";
+        }
+        case "landingPadStatus2": {
+          return "Fighter 2";
+        }
+        case "landingPadStatus3": {
+          return "Fighter 3";
+        }
+        case "landingPadStatus4": {
+          return "Starcaller";
+        }
+        default: {
+          return key;
+        }
+      }
+    },
+    getLandingPadState(value) {
+      switch (value) {
+        case 0: {
+          return "Destroyed";
+        }
+        case 1: {
+          return "Docked";
+        }
+        case 2: {
+          return "Launched";
+        }
+        default: {
+          return String(value) + " (unknown)";
+        }
+      }
+    },
+    getLandingPadClass(value) {
+      switch (value) {
+        case 0: {
+          return "landing-pad-status-destroyed";
+        }
+        case 1: {
+          return "landing-pad-status-docked";
+        }
+        case 2: {
+          return "landing-pad-status-launched";
+        }
+        default: {
+          return "";
+        }
+      }
     },
     async makeSetValueRequest(data) {
       this.isLoading = true;
@@ -557,6 +625,35 @@ button {
   font-family: monospace;
   background: #ffeeef;
   padding: 10px;
+}
+.landing-pad-container {
+  display: flex;
+  flex-direction: row;
+}
+.landing-pad-status {
+  border: 1px solid #f00;
+  padding: 0.5rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 0.2rem;
+}
+.landing-pad-status:not(:last-child) {
+  margin-right: 0.5rem;
+}
+
+.landing-pad-status-destroyed {
+  border: 1px solid #dc3545;
+}
+
+.landing-pad-status-docked {
+  border: 1px solid #28a745;
+}
+
+.landing-pad-status-launched {
+  border: 1px solid #ffc107;
 }
 h2 {
   margin: auto;

--- a/src/components/EmptyEpsilon.vue
+++ b/src/components/EmptyEpsilon.vue
@@ -26,7 +26,7 @@
           <h2>Empty Epsilon state</h2>
           <vue-json-pretty :data="gameState" class="ee-state"></vue-json-pretty>
         </b-col>
-        <b-col cols="8">
+        <b-col cols="9">
             <div class="ee-status-container">
               <h3>
               Connection status:
@@ -538,8 +538,8 @@ export default {
       await this.setValue();
 
       // And landing pad statuses
-      const landingPads = Object.getEntries(
-        get(this.gameState, "landingPads", {}),
+      const landingPads = Object.entries(
+        _.get(this.gameState, "landingPads", {}),
       );
       for (const [pad, value] of landingPads) {
         const target = pad.replace("landingPadStatus", "");
@@ -586,7 +586,9 @@ button {
 }
 .ee-state {
   background: #eee;
-  padding: 8px;
+  padding: 12px;
+  border-radius: 0.25rem;
+  border: 1px solid #ccc;
 }
 .vjs-tree {
   line-height: 1em;

--- a/src/views/EmptyEpsilon.vue
+++ b/src/views/EmptyEpsilon.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="about">
-    <b-container fluid class="my-4">
-      <h1>Empty Epsilon</h1>
-    </b-container>
     <EmptyEpsilon />
   </div>
 </template>


### PR DESCRIPTION
Improve the usability of Empty Epsilon admin view and show landing pad statuses.

## Screenshot
<img width="1466" alt="Screenshot 2024-06-22 at 10 49 43" src="https://github.com/OdysseusLarp/odysseus-admin/assets/16757571/c1ddbf41-a00f-4877-adbf-7411ea2e1b1a">
