### PR TITLE
Hide automated operations by default

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,11 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title>odysseus-admin</title>
-    <!--
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons">
-    -->
+    <title>Odysseus admin</title>
   </head>
   <body>
     <noscript>

--- a/src/App.vue
+++ b/src/App.vue
@@ -117,9 +117,11 @@ export default {
         get(shipMetadata, "data.ee_connection_enabled")
       );
       const npcMessages = messages.data.filter((m) => !m.receiver.is_character);
-      this.operationsPendingCount = (operations.data || []).filter(
-        (o) => o.is_analysed,
-      ).length;
+      this.operationsPendingCount = (operations.data || []).filter((o) => {
+        const isAnalysed = o.is_analysed;
+        const isNotAutomated = !isAutomatedSample(o);
+        return isAnalysed && isNotAutomated;
+      }).length;
       this.socialPendingCount =
         posts.data.length + votes.data.length + npcMessages.length;
     },

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -27,14 +27,14 @@
       </tr>
 
     </table>
-
+    <hr />
     <h2>Artifacts</h2>
     <Artifact artifactId="power_source" />
     <Artifact artifactId="jump_drive_cooldown" />
     <Artifact artifactId="calibration_slot" />
     <Artifact artifactId="scan_range_extender" />
     <Artifact artifactId="calibration_speedup" />
-
+    <hr />
     <h2>Fuses</h2>
     <FuseStatus boxId="fusebox_bridge" />
     <FuseStatus boxId="fusebox_engineering" />

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,6 @@
 import { format } from "date-fns";
 
-export function pushError(
-  errors: string[] = [],
-  error: Error | string,
-  $notify?: Function,
-) {
+export function pushError(errors: string[] = [], error: Error | string, $notify?: Function) {
   errors.push(`[${format(Date.now(), "HH:mm:ss")}] ${error}`);
   if ($notify)
     $notify({
@@ -12,4 +8,13 @@ export function pushError(
       text: "" + error,
       type: "error",
     });
+}
+
+const AUTOMATED_SAMPLES = ["MATERIAL_SAMPLE", "MICROSCOPE_SAMPLE", "AGE", "HISTORY_SAMPLE", "XRF_SAMPLE"];
+
+export function isAutomatedSample(sample: any) {
+  if (!sample || !sample.additional_type) {
+    return false;
+  }
+  return AUTOMATED_SAMPLES.includes(sample.additional_type);
 }


### PR DESCRIPTION
HANSCA operations (artifact scans, medical tests) that deliver their results automatically will no longer appear in the operations view by default, because these operations do not require any actions from GMs.